### PR TITLE
Set up and add benchmarks for the Outlines library

### DIFF
--- a/.github/workflows/asv_benchmarks_pr.yml
+++ b/.github/workflows/asv_benchmarks_pr.yml
@@ -1,0 +1,54 @@
+name: Benchmark PR
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+env:
+  PYTHON_VERSION: "3.10"
+  WORKING_DIR: ${{ github.workspace }}/src
+  BENCHMARKS_OUTPUT: ${{ github.workspace }}/benchmarks_output
+
+jobs:
+  benchmark-pr:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.WORKING_DIR }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install asv virtualenv lf-asv-formatter
+
+    - name: Create ASV machine config file
+      run: asv machine --machine gh-runner --yes
+
+    - name: Run Benchmarks - `PR HEAD` vs `main`
+      run: |
+        # prepare main branch for comparison
+        git remote add upstream https://github.com/${{ github.repository }}.git
+        git fetch upstream main
+
+        # Run benchmarks, allow errors, they will be caught in the next step
+        asv continuous upstream/main HEAD \
+            --no-stats --interleave-rounds -a repeat=3 || true
+
+    - name: BENCHMARK RESULTS
+      run: |
+        asv compare --factor=1.1 --no-stats --split upstream/main HEAD | tee ${{ env.BENCHMARKS_OUTPUT }}
+        if grep -q "Benchmarks that have got worse" "${{ env.BENCHMARKS_OUTPUT }}"; then
+          echo "Performance degradation detected!"
+          exit 1
+        fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+results
+__pycache__

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+    -   id: check-merge-conflict
+    -   id: debug-statements
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+- repo: https://github.com/pycqa/isort
+  rev: 5.12.0
+  hooks:
+    - id: isort
+      args: [--profile, black]
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.3.1
+  hooks:
+    - id: pyupgrade
+      args: [--py37-plus]
+- repo: https://github.com/pycqa/flake8
+  rev: 6.0.0
+  hooks:
+   - id: flake8
+- repo: https://github.com/psf/black
+  rev: 23.3.0
+  hooks:
+    - id: black

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# benchmarks
-Benchmark structured generation libraries
+# Benchmarks
+
+Benchmark structured generation libraries:
+
+- [Oultines](https://github.com/outlines-dev/outlines)

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,20 @@
+{
+    "version": 1,
+    "project": "Benchmarks",
+    "project_url": "https://outlines-dev.github.io/benchmarks/",
+    "repo": "..",
+    "branches": [
+	"HEAD"
+    ],
+    "build_command": [
+        "python -mpip .",
+        "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}",
+    ],
+    "environment_type": "virtualenv",
+    "show_commit_url": "https://github.com/outlines-dev/benchmarks/commit/",
+    "benchmark_dir": ".",
+    "env_dir": "env",
+    "results_dir": "results",
+    "html_dir": "html",
+    "build_cache_size": 8
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "outlines_benchmark"
+version = "0.1"
+authors = [{"name" = "The Outlines developers"}]
+description = "A benchmarking suite for structured generation libraries."
+requires-python = ">=3.10"
+dependencies = ["outlines==0.0.46", "transformers==4.44.0", "torch==2.4.0"]

--- a/src/outlines.py
+++ b/src/outlines.py
@@ -1,0 +1,39 @@
+"""Benchmark the Outlines library."""
+from transformers import AutoTokenizer
+
+from outlines.fsm.guide import RegexGuide
+from outlines.models.transformers import TransformerTokenizer
+
+models = [
+    "meta-llama/Llama-2-7b-hf",  # 32,000 tokens vocabulary
+    "gpt2",  # 50,257 tokens vocabulary
+    "meta-llama/Meta-Llama-3.1-8B-Instruct",  # 128,256 tokens vocabulary
+    "google/gemma-2-2b-it",  # 256,128 tokens vocabulary
+]
+
+case = (r"\d{3}-\d{2}-\d{4}", "203-22-1234")
+
+
+class Outlines:
+    params = [models, case]
+    param_names = ["model", "regex"]
+    timeout = 600
+
+    def setup(self, model, _):
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            model, clean_up_tokenization_spaces=True
+        )
+        self.tokenizer = TransformerTokenizer(self.tokenizer)
+        # The purpose of the following line is to force the JIT-compilation
+        # of Numba functions, and the type conversion.
+        RegexGuide("a", self.tokenizer)
+
+    def time_outlines(self, _, regex):
+        regex_string, regex_example = regex
+        regex_example_tokens = self.tokenizer.encode(regex_example)[0][0]
+        guide = RegexGuide(regex_string, self.tokenizer)
+
+        state = 0
+        for token in regex_example_tokens:
+            _ = guide.get_next_instruction(state)
+            state = guide.get_next_state(state, token)


### PR DESCRIPTION
In this PR we set up the benchmarking library using [airspeed velocity](https://github.com/airspeed-velocity/asv). We pin the versions of each library so bumping the version requires a new PR.

Regarding Outlines, we benchmark the library *without Numba's JIT-compilation and type conversion for the vocabulary*. Those only need to be executed once per run, and will soon be eliminated with the implementation in a compiled language.