### PR TITLE
Only show results when PR merged on `main`

### DIFF
--- a/.github/workflows/asv_benchmark_main.yml
+++ b/.github/workflows/asv_benchmark_main.yml
@@ -1,7 +1,7 @@
-name: Benchmark PR
+name: Benchmark
 
 on:
-  pull_request:
+  push:
     branches: [main]
 env:
   PYTHON_VERSION: "3.10"
@@ -9,7 +9,7 @@ env:
   BENCHMARKS_OUTPUT: ${{ github.workspace }}/results
 
 jobs:
-  benchmark-pr:
+  benchmark:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -42,13 +42,8 @@ jobs:
         git fetch upstream main
 
         # Run benchmarks, allow errors, they will be caught in the next step
-        asv continuous upstream/main HEAD \
-            --no-stats --interleave-rounds -a repeat=3 || true
+        asv run --interleave-rounds -a repeat=3 || true
 
     - name: BENCHMARK RESULTS
       run: |
-        asv compare --factor=1.1 --no-stats --split upstream/main HEAD | tee ${{ env.BENCHMARKS_OUTPUT }}
-        if grep -q "Benchmarks that have got worse" "${{ env.BENCHMARKS_OUTPUT }}"; then
-          echo "Performance degradation detected!"
-          exit 1
-        fi
+        asv show HEAD | tee ${{ env.BENCHMARKS_OUTPUT }}


### PR DESCRIPTION
In this PR we change the GH workflows so that we only benchmark and display the results once when the PR is merged on `main` (instead of currently "comparing" `main` with `main`).